### PR TITLE
Deprecate master, move to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,11 @@
 name: RNS build and deploy
 
 on:
-  pull_request:
-    branches:
-      - master
-    types: [closed] 
+  push:
+    branches: [ main, develop ]
 
 jobs:
   testnet_build_and_deploy:
-    
-    if: github.event.pull_request.merged == true 
 
     runs-on: ubuntu-latest
 
@@ -44,8 +40,6 @@ jobs:
         aws cloudfront create-invalidation --distribution-id ${{ secrets.TESTNET_CLOUDFRONT_DISTRIBUTION }} --paths "/*"
 
   mainnet_build_and_deploy:
-    
-    if: github.event.pull_request.merged == true 
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
      </a>
 </p>
 
-## Run locally
+## Run for development
 
 Requisites:
 
@@ -36,6 +36,8 @@ Install dependencies:
 ```
 yarn
 ```
+
+### Run locally
 
 1. Run a local blockhain:
     - Preferred: [RSK node](https://developers.rsk.co/quick-start/step1-install-rsk-local-node/)
@@ -53,9 +55,9 @@ yarn start
 
 > Connect your browser wallet to local environment using 'Custom RPC' option
 
-## Run on public networks
+### Run locally against public networks
 
-For RSK Mainnet 
+For RSK Mainnet
 
 ```
 yarn start:mainnet
@@ -67,7 +69,7 @@ For RSK Testnet
 yarn start:testnet
 ```
 
-## Run tests
+### Run tests
 
 The testing suite will first install the RNS suite on a local blockchain before running. To make sure this works properly, start Ganache, and set the URL and port in `/tests/setEnvVars.js`.
 
@@ -88,11 +90,15 @@ Update snapshots and run watcher:
 yarn test:watch -u
 ```
 
-## Develop
+### Branching model
 
-- `master` points to last productive build
-- `develop` points to last approved pull request
-- Other branches are feature branches, based on develop
+- `main` has latest release. Merge into `main` will deploy to S3. Do merge commits.
+- `develop` has latest approved PR. Do squash & merge.
+
+PRs:
+- Use branches pointing to latest commit in `develop`
+- Need to pass `ci` and LGTM
+- Will deploy to Github Pages
 
 ## Build
 


### PR DESCRIPTION
Updates ci, cd and readme to point to `main`. I pushed the branch even with `develop` and set its rules. We can then point `v2.1.6` to it (#444)

Reason: the last 3 releases were a pain due to branch conflicts