### PR TITLE
Fix broken images on deployment

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -1,4 +1,3 @@
-
 name: Github Pages Deploy
 
 on:

--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install and Build for Testnet 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           yarn
-          yarn build:testnet
+          yarn build:ghpages
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:

--- a/README.md
+++ b/README.md
@@ -131,4 +131,3 @@ Testnet:
 docker build -t rns-manager-testnet . -f testnet.Dockerfile
 docker run -d --name rns-manager-testnet -p 5001:5001 rns-manager-testnet
 ```
-

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.10",
   "private": true,
   "license": "MIT",
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "@ensdomains/address-encoder": "^0.1.8",
     "@githubprimer/octicons-react": "^8.5.0",
@@ -47,6 +47,7 @@
     "start:mainnet": "env-cmd -f .env.production react-scripts start",
     "build:testnet": "CI=false env-cmd -f .env.testnet react-scripts --max_old_space_size=8192 build",
     "build:mainnet": "CI=false env-cmd -f .env.production react-scripts --max_old_space_size=8192 build",
+    "build:ghpages": "PUBLIC_URL=/rns-manager-react CI=false env-cmd -f .env.testnet react-scripts --max_old_space_size=8192 build",
     "test": "node ./tests/setupRnsSuite.js && jest --maxWorkers=4 && eslint src",
     "test:watch": "node ./tests/setupRnsSuite.js && jest --watch",
     "cypress": "cypress open",

--- a/src/app/components/FooterComponent.js
+++ b/src/app/components/FooterComponent.js
@@ -92,7 +92,7 @@ const FooterComponent = (props) => {
                 {`Copyright © ${new Date().getFullYear()} `}
                 RSK Labs. All rights reserved.
                 {` ${version}`}
-                ;-)
+                ;-) 2
               </p>
             </Col>
           </Row>

--- a/src/app/components/FooterComponent.js
+++ b/src/app/components/FooterComponent.js
@@ -92,6 +92,7 @@ const FooterComponent = (props) => {
                 {`Copyright © ${new Date().getFullYear()} `}
                 RSK Labs. All rights reserved.
                 {` ${version}`}
+                ;-)
               </p>
             </Col>
           </Row>

--- a/src/app/components/FooterComponent.js
+++ b/src/app/components/FooterComponent.js
@@ -92,7 +92,6 @@ const FooterComponent = (props) => {
                 {`Copyright © ${new Date().getFullYear()} `}
                 RSK Labs. All rights reserved.
                 {` ${version}`}
-                ;-) 2
               </p>
             </Col>
           </Row>

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -24,6 +24,8 @@ const Routes = (props) => {
         !hasContracts && <Route component={ErrorTab} />
       }
       <Route exact path="/" component={HomeTab} />
+      {/* the following path is only for GitHub pages */}
+      <Route exact path="/rns-manager-react" component={HomeTab} />
       <Route path="/search" component={SearchTab} />
       <Route path="/resolve" component={ResolveTab} />
       <Route path="/faq" component={FaqTab} />

--- a/src/app/tabs/newAdmin/addresses/components/YourAddressesComponent.js
+++ b/src/app/tabs/newAdmin/addresses/components/YourAddressesComponent.js
@@ -47,7 +47,7 @@ const YourAddressesComponent = ({
             <ChainAddressEditContainer
               key={chainName}
               label={chainName}
-              labelIcon={`../../assets/icons/${network.icon}`}
+              labelIcon={`${process.env.PUBLIC_URL}/assets/icons/${network.icon}`}
               networkId={chainId}
               value={address}
               isError={isError}


### PR DESCRIPTION
The issue was caused by the homepage attribute being set to `.`. This was done so the GitHub pages deploy worked correctly. This used to work without issue with both production and GH environments. 

This is tested with the GitHub pages deployment and should work with in production. However, there is only one way to find out...
