### PR TITLE
refactor: use partner url identifier in rns-sdk init

### DIFF
--- a/src/app/rns-sdk.js
+++ b/src/app/rns-sdk.js
@@ -8,28 +8,38 @@ import {
   fifsAddrRegistrar as fifsAddrRegistrarAddress,
   renewer,
   rif,
+  getCurrentPartnerAddresses,
 } from './adapters/configAdapter';
 
 const defaultSigner = new ethers.providers.JsonRpcProvider(rskNode).getSigner();
 
-export const registrar = (
-  partnerAddress,
-  signer = defaultSigner,
-) => new PartnerRegistrar(
-  partnerAddress,
-  fifsAddrRegistrarAddress,
-  renewer, rskOwnerAddress,
-  rif,
-  signer,
-);
+export const getCurrentPartner = () => {
+  const searchParams = new URLSearchParams(document.location.search);
+  return searchParams.get('partner') || 'default';
+};
 
-export const partnerConfiguration = (
-  partnerAddress,
+export const registrar = async (
   signer = defaultSigner,
-) => new PartnerConfiguration(
-  partnerAddress,
-  signer,
-);
+) => {
+  const partnerAddresses = await getCurrentPartnerAddresses(getCurrentPartner());
+  return new PartnerRegistrar(
+    partnerAddresses.account,
+    fifsAddrRegistrarAddress,
+    renewer, rskOwnerAddress,
+    rif,
+    signer,
+  );
+};
+
+export const partnerConfiguration = async (
+  signer = defaultSigner,
+) => {
+  const partnerAddresses = await getCurrentPartnerAddresses(getCurrentPartner());
+  return new PartnerConfiguration(
+    partnerAddresses.config,
+    signer,
+  );
+};
 
 export const rns = (
   signer = defaultSigner,


### PR DESCRIPTION
This PR aims to make the init of the rns-sdk more robust by abstracting away the getting/setting of the current active partner of the manager into the sdk init