### PR TITLE
fix: fix rounding error on price display for available name on home

### DIFF
--- a/src/app/tabs/search/operations.js
+++ b/src/app/tabs/search/operations.js
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import {
   requestDomainState, receiveDomainState,
   blockedDomain,
@@ -57,8 +57,8 @@ export default domain => async (dispatch) => {
     dispatch(setMinMaxLength(minLength.toNumber(), maxLength.toNumber()));
 
     const price = await Registrar.price(domain, minDuration.toNumber());
-    const rifCost = price.div(BigNumber.from(10).pow(18));
-    dispatch(receiveDomainCost(rifCost.toNumber()));
+    const rifCost = ethers.utils.formatUnits(price, 18);
+    dispatch(receiveDomainCost(rifCost));
     dispatch(receiveDomainState(available));
   } catch (error) {
     dispatch(notifyError(error.message));


### PR DESCRIPTION
This PR Fixes a bug that rounds the price down instead of displaying the appropriate decimal value for available names on the home page for partner with discount percentage lower than 50%