### PR TITLE
fix: use correct regex to prevent incorrect domain namelogin

### DIFF
--- a/src/app/auth/components/LoginFormComponent.js
+++ b/src/app/auth/components/LoginFormComponent.js
@@ -16,7 +16,7 @@ const LoginFormComponent = ({
       return;
     }
 
-    if (domainInput.match('^[a-z0-9!@#$%^&*()-_+={}[\]\\|;:\'",<>?/`~\\p{L}\\p{N}]*$') !== null) { /* eslint-disable-line */
+    if (domainInput.match('^[a-z0-9!@#$%^&*()-_+={}[\]\|;:\'",<>?/`~\p{L}\p{N}]*$') !== null) { /* eslint-disable-line */
       setLocalError(strings.invalid_name);
       return;
     }


### PR DESCRIPTION
This PR fixes a bug where the manager incorrectly attempts to login an owned domain with additional decimal points before the .rsk extension