### PR TITLE
fix: issue fix for results section overlap on mobile screens

### DIFF
--- a/src/assets/css/sass/home/_searchResults.scss
+++ b/src/assets/css/sass/home/_searchResults.scss
@@ -78,6 +78,7 @@
 @media (max-width: 767.98px) {
   .results h2 {
     text-align: center;
+    margin-top: 15%;
   }
 
   .searchResults {


### PR DESCRIPTION
This PR fixes the issue where the result section was not rendering properly on smaller screens.
![Screenshot 2024-02-29 at 3 45 05 PM](https://github.com/rsksmart/rns-manager-react/assets/27959051/271b80da-0094-40de-86d3-7065a5b881ea)
