### PR TITLE
fix: issue fix for results section overlap on mobile screens

### DIFF
--- a/src/assets/css/sass/home/_searchResults.scss
+++ b/src/assets/css/sass/home/_searchResults.scss
@@ -78,6 +78,7 @@
 @media (max-width: 767.98px) {
   .results h2 {
     text-align: center;
+    margin-top: 15%;
   }
 
   .searchResults {


### PR DESCRIPTION
This PR fixes the issue where the result section was not rendering properly on smaller screens.
![Screenshot 2024-02-29 at 3 51 21 PM](https://github.com/rsksmart/rns-manager-react/assets/27959051/18172b70-21b8-41f2-a2db-0153c6541f6c)
