### PR TITLE
chore: update syntax to more modern usage

### DIFF
--- a/src/app/tabs/resolve/components/ResolveComponent.js
+++ b/src/app/tabs/resolve/components/ResolveComponent.js
@@ -12,10 +12,10 @@ import {
 import UserWaitingComponent from '../../../components/UserWaitingComponent';
 
 const renderResolutions = (supportedInterfaces) => {
-  const hasAddr = supportedInterfaces.indexOf('addr') > -1;
-  const hasChainAddr = supportedInterfaces.indexOf('chainAddr') > -1;
-  const hasMulticoin = supportedInterfaces.indexOf('multicoin') > -1;
-  const hasName = supportedInterfaces.indexOf('name') > -1;
+  const hasAddr = supportedInterfaces.includes('addr');
+  const hasChainAddr = supportedInterfaces.includes('chainAddr');
+  const hasMulticoin = supportedInterfaces.includes('multicoin');
+  const hasName = supportedInterfaces.includes('name');
 
   return (
     <Container className="page">


### PR DESCRIPTION
The behaviour reported in this [issue](https://rsklabs.atlassian.net/browse/REM-43) and the approach taken by this [fix](https://github.com/rsksmart/rns-manager-react/pull/559) doesn't apply here because in the case of the [disposable-main branch](https://github.com/rsksmart/rns-manager-react/tree/disposable-main) which uses the web3 library to interact with the RNS contract (which has the multichain support) directly, the updated version of this project which uses the rns-sdk has no support for multichain at the time of creating this pr. Hence the changes in this PR reference only a syntax update for the piece of code under review.